### PR TITLE
Redesign Speakers Page with Speaker Callout and Improved Layout

### DIFF
--- a/src/app/speakers/page.jsx
+++ b/src/app/speakers/page.jsx
@@ -5,15 +5,38 @@ export default function SpeakersPage() {
   // Sample speakers data
 
   return (
-    <>
-      <main className="max-w-5xl mx-auto p-4 wrapper-pages">
-        <PageHero 
-          title="Speakers" 
-          subtitle="Meet our distinguished speakers for BSides SWFL 2025." 
-        />
-        
-        <script type="text/javascript" src={`https://sessionize.com/api/v2/${process.env.NEXT_PUBLIC_SESSIONIZE_KEY}/view/SpeakerWall`}></script>
-      </main>
-    </>
+    <main className="min-h-screen wrapper-pages">
+      <PageHero 
+        title="Our Speakers" 
+        subtitle="Get ready to learn from a diverse lineup of experts, innovators, and passionate professionals sharing their knowledge across cybersecurity disciplines. Whether it's offensive, defensive, or everything in between, these speakers bring real-world experience and fresh perspectives to the BSides SWFL stage." 
+      />
+
+      {/* Call For Action Section */}
+      <div className="max-w-5xl mx-auto px-6 py-16 text-slate-800 text-center">
+        <h2 className="text-2xl md:text-3xl font-bold mb-4">Call for Speakers Now Open</h2>
+        <p className="text-lg text-slate-700 mb-4">
+          Have a talk, workshop, or idea that belongs on the BSides SWFL stage? We’re now accepting proposals from speakers of all backgrounds and experience levels.
+        </p>
+        <p className="text-lg text-slate-700 mb-4">
+          Whether you're sharing technical skills, research, lessons learned, or unique stories from the field — we want to hear from you.
+        </p>
+      </div>
+
+      <div className="text-center -mt-10 pb-30">
+        <a href='https://sessionize.com/bsidesswfl2025/'>
+          <button className="bg-teal-600 text-white font-bold py-3 px-8 rounded-lg shadow-md hover:bg-teal-700 transition-colors duration-200 w-full md:w-auto">
+            Reach Out Today! <img className="inline-block w-12 h-12 ml-4" src="bsideslogo.png" />
+          </button>
+        </a>
+      </div>
+
+      {/* Embedded SpeakerWall */}
+      <div className="max-w-6xl mx-auto px-6 pb-16">
+        <script 
+          type="text/javascript" 
+          src={`https://sessionize.com/api/v2/${process.env.NEXT_PUBLIC_SESSIONIZE_KEY}/view/SpeakerWall`}>
+        </script>
+      </div>
+    </main>
   )
 }


### PR DESCRIPTION
Enhance the Speakers page by adding a vibrant call-to-action section for speaker recruitment, improving the layout, and updating the `PageHero` with a more engaging subtitle. The new design encourages participation in the call for speakers and provides a better user experience with consistent styling and responsive design.

Fixes #70