### PR TITLE
Refactor Workshops Page with Embedded Form

### DIFF
--- a/src/app/workshops/page.jsx
+++ b/src/app/workshops/page.jsx
@@ -8,16 +8,21 @@ export default function Workshops() {
     <main className="min-h-screen wrapper-pages">
       <PageHero 
         title="Lead a Workshop, Share What You Know" 
-        subtitle="Want to lead a workshop at BSides SWFL 2025? We’re looking for hands-on, 3-4 hour sessions to run on Friday that dive deep into real skills and practical takeaways. Whether you’re into red teaming, blue teaming, OSINT, reverse engineering, or something totally offbeat, we want sessions that challenge and inspire. You don’t need to be a seasoned presenter, just bring your knowledge, your passion, and a plan to get people learning." 
+        subtitle="Our workshops offer immersive, hands-on sessions that dig deep into practical skills across the cybersecurity spectrum. Whether you’re teaching red teaming, OSINT, or something uniquely your own, this is your space to inspire learning and lead with impact." 
       />
 
-      <div className="text-center mt-12">
+      <div className="max-w-5xl mx-auto wrapper-pages p-4 md:mb-12 pt-4">
+        <div className="hs-form-frame mt-6 mb-12" data-region="na2" data-form-id="6fc72569-d746-41a3-a5a0-3e8b930742d2" data-portal-id="242985282"></div>
+      </div>
+
+      {/* Call To Action Button - Hidden until sessions are approved */}
+      {/* <div className="text-center mt-12">
         <a href='/workshops-form'>
           <button className="bg-teal-600 text-white font-bold py-3 px-8 rounded-lg shadow-md hover:bg-teal-700 transition-colors duration-200 w-full md:w-auto">
             Reach Out Today! <img className="inline-block w-12 h-12 ml-4" src="bsideslogo.png" />
           </button>
         </a>
-      </div>
+      </div> */}
     </main>
   )
 }


### PR DESCRIPTION
Embed the HubSpot form directly on the Workshops page to enhance user experience and reduce friction. Update the layout with improved styling and spacing, and refine the PageHero messaging for a more engaging tone. Comment out the legacy CTA button for potential future use. This change modernizes the design and aligns the page with the overall site aesthetics.

Fixes #72