### PR TITLE
Update Layout Main Wrapper Height to min-h-screen for Improved Page Sizing

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -40,7 +40,7 @@ export default function RootLayout({ children }) {
           <source src="/video.mp4" type="video/mp4" />
         </video>
         <Navbar />
-        <main className="max-w-5xl w-auto h-auto md:h-[90vh] md:w-[100vw] bg-gradient-to-br from-amber-50 via-orange-50 to-red-50  mx-auto rounded-t-2xl opacity-92 md:opacity-98">
+        <main className="max-w-5xl w-auto min-h-screen md:w-[100vw] bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 mx-auto rounded-t-2xl opacity-92 md:opacity-98">
           {children}
         </main>
         <Footer />


### PR DESCRIPTION
Adjust the main content wrapper to use `min-h-screen` instead of `h-auto md:h-[90vh]`. This change enhances layout consistency and ensures that pages with less content occupy the full screen height, improving overall page sizing and rendering across different screen sizes.

Fixes #78