### PR TITLE
Replace Villages HubSpot Form with Sessionize Call for Sessions CTA and Updated Content

### DIFF
--- a/src/app/villages/page.jsx
+++ b/src/app/villages/page.jsx
@@ -12,18 +12,25 @@ export default function Villages() {
         subtitle="Villages are all-day interactive spaces where attendees can get hands-on, ask questions, and explore niche areas of security. Whether it's lockpicking, social engineering, or career building, villages turn curiosity into connection through real-world experience."
       />
 
-      <div className="max-w-5xl mx-auto wrapper-pages p-4 md:mb-12 pt-4">
-        <div className="hs-form-frame mt-6 mb-12" data-region="na2" data-form-id="fb4869ea-c35c-4d70-9ddb-7508f9d6cf1f" data-portal-id="242985282"></div>
+      <div className="max-w-5xl mx-auto px-6 py-16 text-slate-800 text-center">
+        <h2 className="text-2xl md:text-3xl font-bold mb-4">Call for Villages Now Open</h2>
+        <p className="text-lg text-slate-700 mb-4">
+          Have an idea for a hands-on, interactive space that brings people together around a shared area of interest in cybersecurity? BSides SWFL is accepting village proposals for Saturday, November 15th.
+        </p>
+        <p className="text-lg text-slate-700 mb-4">
+          Villages are open all day and give attendees the chance to explore, experiment, and engage — whether it’s lockpicking, social engineering, hardware hacking, career coaching, or something brand new.
+        </p>
+        <p className="text-lg text-slate-700 mb-4">
+          We’re looking for creative and inclusive experiences. Tell us your vision, how attendees will interact, and what you’ll need to make it happen.
+        </p>
       </div>
 
-      {/* Call To Action Button - Hidden until sessions are approved */}
-      {/* <div className="text-center mt-12">
-        <Link href='/villages-form'>
-          <button className="bg-teal-600 text-white font-bold py-3 px-8 rounded-lg shadow-md hover:bg-teal-700 transition-colors duration-200 w-full md:w-auto">
-            Reach Out Today! <img className="inline-block w-12 h-12 ml-4" src="bsideslogo.png" />
+      <div className="text-center -mt-10 pb-30">
+        <a href='https://sessionize.com/bsidesswfl2025/'>
+          <button className="bg-teal-600 text-white font-bold py-3 px-8 rounded-lg shadow-md hover:bg-teal-700 transition-colors duration-200 w-[90%] md:w-auto"> Reach Out Today! <img className="inline-block w-12 h-12 ml-4" src="bsideslogo.png" />
           </button>
-        </Link>
-      </div> */}
+        </a>
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
Updated the Villages page to remove the outdated HubSpot form and replace it with a direct call-to-action button linking to the Sessionize CFS. Added new content to clarify the call for villages and enhance user engagement. Fixes #91