### PR TITLE
Add additional subtitle content in About Us section

### DIFF
--- a/src/app/aboutus/page.jsx
+++ b/src/app/aboutus/page.jsx
@@ -51,7 +51,7 @@ export default function AboutUs() {
     <main className="min-h-screen wrapper-pages">
       <PageHero 
         title="About Us"
-        subtitle="Built by the community, for the community—BSides SWFL is where curiosity meets collaboration, and cybersecurity feels personal."
+        subtitle="BSides SWFL is a community-built cybersecurity event where professionals, students, and enthusiasts come together to share ideas, gain hands-on experience, and grow the local infosec community. We celebrate curiosity, support newcomers, and provide a space where everyone can contribute."
       />
 
       {/* Main content */}


### PR DESCRIPTION
Enhance the subtitle in the About Us section to provide more context and uniformity with other pages. This change addresses issue #87 by ensuring the subtitle fills the appropriate amount of lines in both web and mobile views.