### PR TITLE
Center Lucid Services Group logo in Bronze sponsors

### DIFF
--- a/src/app/sponsors/page.jsx
+++ b/src/app/sponsors/page.jsx
@@ -23,7 +23,7 @@ const SponsorsPage = () => {
   ];
 
   const bronzeSponsors = [
-    { name: "", logo: <Link href="https://www.lucidservicesgroup.com"><img src="/LucidServicesGroup.png" alt="Lucid Services Group" className="h-24 ml-1 w-auto mx-auto" /></Link>, website: "" },
+    { name: "", logo: <Link href="https://www.lucidservicesgroup.com"><img src="/LucidServicesGroup.png" alt="Lucid Services Group" className="h-24 w-auto mx-auto" /></Link>, website: "" },
     { name: "Your Name Here", logo: "🎓", website: "https://www.bsidesswfl.org/sponsor-form" },
     { name: "Your Logo Could Be Famous", logo: "🔧", website: "https://www.bsidesswfl.org/sponsor-form" },
     { name: "Let's Make This Official", logo: "🦠", website: "https://www.bsidesswfl.org/sponsor-form" },


### PR DESCRIPTION
This PR fixes the centering of the Lucid Services Group logo in the Bronze sponsors section.

## Changes:
- ✅ Removed `ml-1` (margin-left) class from Lucid Services Group logo
- ✅ Logo now properly centered using only `mx-auto`

The logo was slightly offset to the right due to the `ml-1` class. This fix ensures it's perfectly centered in the sponsor card.