### PR TITLE
Remove all placeholder sponsor cards

### DIFF
--- a/src/app/sponsors/page.jsx
+++ b/src/app/sponsors/page.jsx
@@ -4,39 +4,17 @@ import Link from 'next/link';
 import PageHero from "../components/page-hero";
 
 const SponsorsPage = () => {
-  const platinumSponsors = [
-    { name: "Become A Sponsor", logo: "🛡️", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Your Name Here", logo: "🔐", website: "https://www.bsidesswfl.org/sponsor-form" }
-  ];
+  const platinumSponsors = [];
 
-  const goldSponsors = [
-    { name: "Become A Sponsor", logo: "🎯", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Your Name Here", logo: "📊", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Your Logo Could Be Famous", logo: "☁️", website: "https://www.bsidesswfl.org/sponsor-form" }
-  ];
+  const goldSponsors = [];
 
-  const silverSponsors = [
-    { name: "Become A Sponsor", logo: "⚡", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Your Name Here", logo: "🚨", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Your Logo Could Be Famous", logo: "🔍", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Swag Bag Royalty", logo: "🔬", website: "https://www.bsidesswfl.org/sponsor-form" },
-  ];
+  const silverSponsors = [];
 
   const bronzeSponsors = [
-    { name: "", logo: <Link href="https://www.lucidservicesgroup.com"><img src="/LucidServicesGroup.png" alt="Lucid Services Group" className="h-24 ml-1 w-auto mx-auto" /></Link>, website: "" },
-    { name: "Your Name Here", logo: "🎓", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Your Logo Could Be Famous", logo: "🔧", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Let's Make This Official", logo: "🦠", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Buy Us Coffee", logo: "🔑", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Sticker Worthy?", logo: "📋", website: "https://www.bsidesswfl.org/sponsor-form" }
+    { name: "", logo: <Link href="https://www.lucidservicesgroup.com"><img src="/LucidServicesGroup.png" alt="Lucid Services Group" className="h-24 ml-1 w-auto mx-auto" /></Link>, website: "" }
   ];
 
-  const communitySponsors = [
-    { name: "Become A Community Sponsor", logo: "🏛️", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Your Name Here", logo: "🎓", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Your Logo Could Be Famous", logo: "🌐", website: "https://www.bsidesswfl.org/sponsor-form" },
-    { name: "Let's Make This Official", logo: "👥", website: "https://www.bsidesswfl.org/sponsor-form" }
-  ];
+  const communitySponsors = [];
 
   // SponsorCard component
   const sizeClasses = {
@@ -192,50 +170,60 @@ const SponsorsPage = () => {
 
         {/* Sponsors Section */}
         <div className="container mx-auto items-center justify-center text-center px-6 py-16 pb-30 lg:pb-32">
-          <SponsorTier
-            title="Platinum Sponsors"
-            sponsors={platinumSponsors}
-            tierColor="bg-gradient-to-r from-slate-500 to-gray-600"
-            icon={Award}
-            cardSize="large"
-            description="Our premier partners who provide exceptional support for the BSides SWFL community"
-          />
+          {platinumSponsors.length > 0 && (
+            <SponsorTier
+              title="Platinum Sponsors"
+              sponsors={platinumSponsors}
+              tierColor="bg-gradient-to-r from-slate-500 to-gray-600"
+              icon={Award}
+              cardSize="large"
+              description="Our premier partners who provide exceptional support for the BSides SWFL community"
+            />
+          )}
 
-          <SponsorTier
-            title="Gold Sponsors"
-            sponsors={goldSponsors}
-            tierColor="bg-gradient-to-r from-amber-500 to-orange-600"
-            icon={Award}
-            cardSize="medium"
-            description="Strategic partners committed to advancing cybersecurity education in Southwest Florida"
-          />
+          {goldSponsors.length > 0 && (
+            <SponsorTier
+              title="Gold Sponsors"
+              sponsors={goldSponsors}
+              tierColor="bg-gradient-to-r from-amber-500 to-orange-600"
+              icon={Award}
+              cardSize="medium"
+              description="Strategic partners committed to advancing cybersecurity education in Southwest Florida"
+            />
+          )}
 
-          <SponsorTier
-            title="Silver Sponsors"
-            sponsors={silverSponsors}
-            tierColor="bg-gradient-to-r from-cyan-500 to-teal-600"
-            icon={Shield}
-            cardSize="small"
-            description="Valued supporters helping us deliver world-class security content and Gulf Coast networking"
-          />
+          {silverSponsors.length > 0 && (
+            <SponsorTier
+              title="Silver Sponsors"
+              sponsors={silverSponsors}
+              tierColor="bg-gradient-to-r from-cyan-500 to-teal-600"
+              icon={Shield}
+              cardSize="small"
+              description="Valued supporters helping us deliver world-class security content and Gulf Coast networking"
+            />
+          )}
 
-          <SponsorTier
-            title="Bronze Sponsors"
-            sponsors={bronzeSponsors}
-            tierColor="bg-gradient-to-r from-orange-600 to-red-700"
-            icon={Zap}
-            cardSize="tiny"
-            description="Essential contributors to our mission of building a stronger SWFL security community"
-          />
+          {bronzeSponsors.length > 0 && (
+            <SponsorTier
+              title="Bronze Sponsors"
+              sponsors={bronzeSponsors}
+              tierColor="bg-gradient-to-r from-orange-600 to-red-700"
+              icon={Zap}
+              cardSize="tiny"
+              description="Essential contributors to our mission of building a stronger SWFL security community"
+            />
+          )}
 
-          <SponsorTier
-            title="Community Sponsors"
-            sponsors={communitySponsors}
-            tierColor="bg-gradient-to-r from-emerald-600 to-teal-700"
-            icon={Heart}
-            cardSize="small"
-            description="Local organizations and groups that champion cybersecurity education in Southwest Florida"
-          />
+          {communitySponsors.length > 0 && (
+            <SponsorTier
+              title="Community Sponsors"
+              sponsors={communitySponsors}
+              tierColor="bg-gradient-to-r from-emerald-600 to-teal-700"
+              icon={Heart}
+              cardSize="small"
+              description="Local organizations and groups that champion cybersecurity education in Southwest Florida"
+            />
+          )}
         </div>
       </div>
     </main>


### PR DESCRIPTION
This PR removes all placeholder sponsor cards while keeping all sponsor tier structures.

## Changes:
- ✅ Removed all placeholder sponsors from all tiers
- ✅ Kept all sponsor tier structures (Platinum, Gold, Silver, Bronze, Community)
- ✅ Only Bronze tier contains actual sponsor: Lucid Services Group
- ✅ Added conditional rendering - empty tiers won't display on the page
- ✅ All sponsor data arrays remain in place for easy future additions

## Result:
The page will only display the Bronze Sponsors section with Lucid Services Group. All placeholder cards with text like 'Your Name Here', 'Become A Sponsor', etc. have been removed. When new sponsors are added to any tier, they will automatically display.