### PR TITLE
Add redirect from /tickets to Luma event registration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: '/tickets',
+        destination: 'https://lu.ma/btwze03o',
+        permanent: false,
+      },
+    ];
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
This PR adds a URL redirect from `/tickets` to the Luma event registration page.

## Resolves
Closes #142

## Changes:
- ✅ Added redirect in `next.config.js` from `/tickets` to `https://lu.ma/btwze03o`
- ✅ Uses temporary redirect (302) for flexibility in case the Luma URL changes
- ✅ When users visit `www.bsidesswfl.org/tickets`, they will be automatically redirected to the Luma event registration page

## Testing:
After deployment, visiting `/tickets` will redirect to the Luma event page instead of showing an empty themed page.

## Marketing Impact:
This enables marketing materials to use the simple `/tickets` URL which redirects to the current event registration platform.