### PR TITLE
Add Hubspot Village Form to /villages page

### DIFF
--- a/src/app/villages/page.jsx
+++ b/src/app/villages/page.jsx
@@ -13,8 +13,8 @@ export default function Villages() {
       />
 
       <div className="max-w-5xl mx-auto wrapper-pages p-4 md:mb-12 pt-4 -mt-12">
-        <div class="hs-form-frame mt-6 mb-14" data-region="na2" data-form-id="fb4869ea-c35c-4d70-9ddb-7508f9d6cf1f" data-portal-id="242985282">
+        <div className="hs-form-frame mt-6 mb-14" data-region="na2" data-form-id="fb4869ea-c35c-4d70-9ddb-7508f9d6cf1f" data-portal-id="242985282"></div>
       </div>
     </main>
-  )
+  );
 }


### PR DESCRIPTION
This pull request updates the village proposal section on the `Villages` page to improve user experience and streamline the submission process. The most important change is replacing the manual call for village proposals and external link with an embedded form.

**User experience improvements:**

* Replaced the previous call for village proposals (including explanatory text and external link/button) with an embedded HubSpot form (`hs-form-frame`) for direct submissions, making it easier for users to propose new villages.

[Preview](https://cw-bsides2025-git-crystalwerni-8fe699-crystalwernickes-projects.vercel.app/villages)