### PR TITLE
fix: Auto-create Cloudflare Pages project on first deploy

### DIFF
--- a/.github/workflows/deploy-simple.yml
+++ b/.github/workflows/deploy-simple.yml
@@ -43,9 +43,17 @@ jobs:
       - name: Build Astro site
         run: npm run build
 
+      - name: Create Cloudflare Pages project (if needed)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create bsides-swfl --production-branch main
+        continue-on-error: true
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=bsides-swfl
+          command: pages deploy dist --project-name=bsides-swfl --branch=${{ github.ref_name }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,3 @@
 name = "bsides-swfl"
 compatibility_date = "2025-01-15"
-
-[site]
-bucket = "./dist"
+pages_build_output_dir = "dist"


### PR DESCRIPTION
## Summary
- Add step to create Pages project if it doesn't exist (with `continue-on-error` for subsequent runs)
- Update wrangler.toml with `pages_build_output_dir` for Pages compatibility
- Add branch tracking to deploy command for staging/main separation

## Problem
The deployment failed with:
```
Project not found. The specified project name does not match any of your existing projects. [code: 8000007]
```

This happened because the Astro migration changed from Cloudflare Workers to Cloudflare Pages, but the Pages project `bsides-swfl` didn't exist yet.

## Test plan
- [ ] Merge this PR
- [ ] Verify the deploy workflow runs successfully on main
- [ ] Check the site is live on Cloudflare Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)