### PR TITLE
fix: Remove Cloudflare adapter for static site deployment

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,14 +1,9 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import react from '@astrojs/react';
-import cloudflare from '@astrojs/cloudflare';
 
 export default defineConfig({
   output: 'static',
-  adapter: cloudflare({
-    mode: 'directory',
-    imageService: 'passthrough'
-  }),
   integrations: [
     tailwind(),
     react()


### PR DESCRIPTION
## Summary
Remove the `@astrojs/cloudflare` adapter since the site uses `output: 'static'`.

## Problem
Deployment failed with:
```
ReferenceError: MessageChannel is not defined
at chunks/_@astro-renderers_-hKnP1mz.mjs:7517:16 in requireReactDomServer_browser_production
```

This happened because the Cloudflare adapter tries to run React SSR in a Cloudflare Worker, but `MessageChannel` isn't available in that runtime.

## Solution
Since the site is fully static (`output: 'static'`), we don't need any adapter. Astro generates plain HTML files that Cloudflare Pages serves directly - no Worker involved.

## Test plan
- [x] Local build succeeds: `npm run build`
- [ ] Merge and verify deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)